### PR TITLE
Default ES URL is invalid

### DIFF
--- a/src/server/config/index.js
+++ b/src/server/config/index.js
@@ -36,7 +36,7 @@ try {
 var config = module.exports = {
   port                    : kibana.port || 5601,
   host                    : kibana.host || '0.0.0.0',
-  elasticsearch           : kibana.elasticsearch_url || 'http           : //localhost : 9200',
+  elasticsearch           : kibana.elasticsearch_url || 'http://localhost:9200',
   root                    : path.normalize(path.join(__dirname, '..')),
   quiet                   : false,
   public_folder           : public_folder,


### PR DESCRIPTION
I hit this issue when trying to run Kibana with a config file that did not have `elasticsearch_url` set.
